### PR TITLE
XSpec integration June 2024 - ci/cd testing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -34,6 +34,6 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           check_name: XSpec Test Results
           comment_mode: always
-          files: "testing/xspec-results/**/*_junit.xml"
+          files: "testing/xspec-reports/**/*_junit.xml"
           report_individual_runs: true
           deduplicate_classes_by_file_name: false

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,39 @@
+# Rationale and instructions for this GitHub Actions workflow:
+# https://github.com/EnricoMi/publish-unit-test-result-action?tab=readme-ov-file#support-fork-repositories-and-dependabot-branches
+
+name: Publish Test Results
+on:
+  workflow_run:
+    workflows: ["CI"]
+    types:
+      - completed
+permissions: {}
+jobs:
+  test-results:
+    name: Test Results
+    runs-on: ubuntu-latest
+    if: github.event.workflow_run.conclusion != 'skipped'
+    permissions:
+      checks: write
+      pull-requests: write
+      actions: read
+    steps:
+      - name: Download and Extract Artifacts
+        uses: dawidd6/action-download-artifact@246dbf436b23d7c49e21a7ab8204ca9ecd1fe615
+        with:
+          run_id: ${{ github.event.workflow_run.id }}
+          path: artifacts
+      - name: Publish Test Results
+        uses: EnricoMi/publish-unit-test-result-action@8885e273a4343cd7b48eaa72428dea0c3067ea98
+        with:
+          commit: ${{ github.event.workflow_run.head_sha }}
+          action_fail: true
+          fail_on: "test failures"
+          event_file: artifacts/Test Results Event/event.json
+          event_name: ${{ github.event.workflow_run.event }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          check_name: XSpec Test Results
+          comment_mode: always
+          files: "testing/xspec-results/**/*_junit.xml"
+          report_individual_runs: true
+          deduplicate_classes_by_file_name: false

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,14 +23,15 @@ jobs:
           ./setup.sh
           ./xp3.sh lib/GRAB-SAXON.xpl
           ./xp3.sh lib/GRAB-SCHXSLT.xpl
+          ./xp3.sh lib/GRAB-XPROC.xpl
         id: setup
       - name: Run smoketests
         run: |
           ./xp3.sh smoketest/POWER-UP.xpl
-          ./xp3.sh smoketest/SMOKETEST-XSLT.xpl
-          ./xp3.sh smoketest/SMOKETEST-SCHEMATRON.xpl
+          ./xp3.sh smoketest/SMOKETEST-XPROC.xpl
         id: exec_smoketests
       - name: Run tests
         run: |
           ./xp3.sh testing/HARDFAIL-XPROC3-HOUSE-RULES.xpl
+          ./xp3.sh testing/BATCH-XSPEC.xpl
         id: exec_tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,12 +23,12 @@ jobs:
           ./setup.sh
           ./xp3.sh lib/GRAB-SAXON.xpl
           ./xp3.sh lib/GRAB-SCHXSLT.xpl
-          ./xp3.sh lib/GRAB-XPROC.xpl
+          ./xp3.sh lib/GRAB-XSPEC.xpl
         id: setup
       - name: Run smoketests
         run: |
           ./xp3.sh smoketest/POWER-UP.xpl
-          ./xp3.sh smoketest/SMOKETEST-XPROC.xpl
+          ./xp3.sh smoketest/SMOKETEST-XSPEC.xpl
         id: exec_smoketests
       - name: Run tests
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,6 @@ jobs:
         id: setup
       - name: Run smoketests
         run: |
-          ls -lha lib
           ./xp3.sh smoketest/POWER-UP.xpl
           ./xp3.sh smoketest/SMOKETEST-SCHEMATRON.xpl
           ./xp3.sh smoketest/SMOKETEST-XSPEC.xpl
@@ -37,3 +36,23 @@ jobs:
           ./xp3.sh testing/HARDFAIL-XPROC3-HOUSE-RULES.xpl
           ./xp3.sh testing/BATCH-XSPEC.xpl
         id: exec_tests
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3
+        with:
+          name: Test Results
+          path: |
+            # JUnit results of pipeline ./testing/BATCH-XSPEC-JUNIT.xpl
+            testing/xspec-results/**.*_junit.xml
+
+  event_file:
+    name: "Upload Results to Event File"
+    runs-on: ubuntu-20.04
+    needs: test
+    steps:
+    - name: Upload
+      uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3
+      with:
+        name: Test Results Event
+        path: ${{ github.event_path }}
+

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,6 +28,7 @@ jobs:
       - name: Run smoketests
         run: |
           ./xp3.sh smoketest/POWER-UP.xpl
+          ./xp3.sh smoketest/SMOKETEST-SCHEMATRON.xpl
           ./xp3.sh smoketest/SMOKETEST-XSPEC.xpl
         id: exec_smoketests
       - name: Run tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Run tests
         run: |
           ./xp3.sh testing/HARDFAIL-XPROC3-HOUSE-RULES.xpl
-          ./xp3.sh testing/BATCH-XSPEC.xpl
+          ./xp3.sh testing/BATCH-XSPEC-JUNIT.xpl
         id: exec_tests
       - name: Upload test results
         if: always()

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,7 @@ jobs:
         id: setup
       - name: Run smoketests
         run: |
-          ls -lha
+          ls -lha lib
           ./xp3.sh smoketest/POWER-UP.xpl
           ./xp3.sh smoketest/SMOKETEST-SCHEMATRON.xpl
           ./xp3.sh smoketest/SMOKETEST-XSPEC.xpl

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,7 +1,16 @@
+name: CI
 on:
   push:
-  pull_request:
-name: CI
+    branches:
+      - main
+      - develop
+  pull_request: {}
+permissions:
+  checks: write
+  pull-requests: write  
+env:
+  JAVA_VERSION: "17"
+  JAVA_DISTRIBUTION: "temurin"
 jobs:
   test:
     name: Test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,6 +27,7 @@ jobs:
         id: setup
       - name: Run smoketests
         run: |
+          ls -lha
           ./xp3.sh smoketest/POWER-UP.xpl
           ./xp3.sh smoketest/SMOKETEST-SCHEMATRON.xpl
           ./xp3.sh smoketest/SMOKETEST-XSPEC.xpl

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,7 +43,7 @@ jobs:
           name: Test Results
           # JUnit results of pipeline ./testing/BATCH-XSPEC-JUNIT.xpl
           path: |
-            testing/xspec-results/**.*_junit.xml
+            testing/xspec-results/**/*_junit.xml
 
   event_file:
     name: "Upload Results to Event File"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,7 +43,7 @@ jobs:
           name: Test Results
           # JUnit results of pipeline ./testing/BATCH-XSPEC-JUNIT.xpl
           path: |
-            testing/xspec-results/**/*_junit.xml
+            testing/xspec-reports/**/*_junit.xml
 
   event_file:
     name: "Upload Results to Event File"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,8 +41,8 @@ jobs:
         uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3
         with:
           name: Test Results
+          # JUnit results of pipeline ./testing/BATCH-XSPEC-JUNIT.xpl
           path: |
-            # JUnit results of pipeline ./testing/BATCH-XSPEC-JUNIT.xpl
             testing/xspec-results/**.*_junit.xml
 
   event_file:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,7 +44,6 @@ jobs:
           # JUnit results of pipeline ./testing/BATCH-XSPEC-JUNIT.xpl
           path: |
             testing/xspec-reports/**/*_junit.xml
-
   event_file:
     name: "Upload Results to Event File"
     runs-on: ubuntu-20.04

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ lib/*
 !lib/readme.md
 !lib/GRAB-SAXON.xpl
 !lib/GRAB-SCHXSLT.xpl
+!lib/GRAB-XPROC.xpl
 !lib/morgana-config.xml
 
 # XSpec test results

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Enabling these lightweight, transparent and declarative "logical layers" written
 - [Morgana XProc IIIse][morgana] - XProc 3.0
 - [Saxon-HE][saxon12] - XSLT 3.0/3.1 (and XQuery)
 - [SchXSLT][schxslt] - ISO Schematron / community enhancements
+- [XSpec][xspec] - XSpec - XSLT/XQuery unit testing
 
 These are open-source projects in support of W3C- and ISO-standardized technologies. (Soon to come: [XSpec](https://github.com/xspec/xspec).) Helping to install, configure, and make these work seamlessly, so users do not have to notice, is a goal of this project.
 
@@ -161,6 +162,10 @@ III. To install SchXSLT: [lib/GRAB-SCHXSLT.xpl](lib/GRAB-SCHXSLT.xpl)
 
 To test SchXSLT: [smoketest/SMOKETEST-SCHEMATRON.xpl](smoketest/SMOKETEST-SCHEMATRON.xpl)
 
+IV. To install XSpec: [lib/GRAB-SCHXSLT.xpl](lib/GRAB-XSPEC.xpl)
+
+To test XSPec: [smoketest/SMOKETEST-SCHEMATRON.xpl](smoketest/SMOKETEST-XSPEC.xpl)
+
 <details><summary><bold>Does it work?</bold></summary>
 
 To test your Java installation from the command line:
@@ -196,6 +201,8 @@ Again you should see fine-looking results, this time in XML.
 After installing Saxon, the smoke test [smoketest/SMOKETEST-XSLT.xpl](smoketest/SMOKETEST-XSLT.xpl) will function, returning sensible outputs.
 
 After installing SchXSLT, the smoke test [smoketest/SMOKETEST-SCHEMATRON.xpl](smoketest/SMOKETEST-SCHEMATRON.xpl) will function, returning sensible outputs.
+
+After installing XSpec, the smoke test [smoketest/SMOKETEST-XSPEC.xpl](smoketest/SMOKETEST-XSPEC.xpl) will function, returning sensible outputs.
 
 [Another page offers help](./setup-notes.md) with details on manual setup.
 

--- a/lib/GRAB-XSPEC.xpl
+++ b/lib/GRAB-XSPEC.xpl
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<p:declare-step xmlns:p="http://www.w3.org/ns/xproc"
+   xmlns:c="http://www.w3.org/ns/xproc-step" version="3.0"
+   xmlns:ox="http://csrc.nist.gov/ns/oscal-xproc3"
+   type="ox:GRAB-XSPEC"
+   name="GRAB-XSPEC">
+
+
+   <!-- XSpec is an XSLT-based unit testing framework
+        for XSLT, XQuery and Schematron
+        
+   -->
+   
+   <!--https://github.com/xspec/xspec/archive/refs/tags/v3.0.3.zip-->
+   
+   <p:variable name="download" select="'https://github.com/xspec/xspec/archive/refs/tags/v3.0.3.zip'"/>
+   <!--<p:variable name="download" select="'xspec-3.0.3.zip'"/>-->
+   
+   <p:variable name="archive-basename"  select="'xspec-3.0.3'"/>
+   
+   <p:variable name="zip-name"  select="$archive-basename || '.zip'"/>
+   
+   <p:variable name="libdir" select="resolve-uri('../lib', static-base-uri())"/>
+
+   <p:variable name="prefix" select="'[' || 'GRAB-XSPEC' || ']'"/>
+   
+   <!-- It beginneth -->
+
+   <p:load href="{ $download }" message="{ $prefix } p:load: { $download } ..."/>
+   
+   <p:store href="{ $zip-name }" message="{$prefix} Saving { $zip-name } (thanks XSpec contributors!)"/>
+   <!--<p:identity message="{$prefix} to save { $zip-name }"/>-->
+   
+   <!-- see p:unarchive here: https://spec.xproc.org/3.0/steps/#c.unarchive -->
+   <p:unarchive message="{$prefix} Unzipping { $zip-name }" exclude-filter="example.xml"/>
+      
+   <p:for-each message="{$prefix} Unzipping into directory { $libdir }">
+      <p:variable name="local-path" select="p:document-property(.,'base-uri')
+         => substring-after($download || '/' )"/>
+      <p:variable name="path-here" select="($libdir, $local-path) => string-join('/')"/>
+
+      <!--<p:identity message="{$prefix} Seeing { $local-path} for { $path-here }"/>-->
+      <p:store href="{ $path-here }" message="{$prefix} Saving { $path-here }"/>
+   </p:for-each>
+   
+   <p:identity message="{ $prefix } Test your XSpec capability using ../smoketest/SMOKETEST-XSPEC.xpl"/>
+   
+</p:declare-step>

--- a/lib/readme.md
+++ b/lib/readme.md
@@ -14,15 +14,37 @@ Expect runtime errors from processing if libraries are missing or named incorrec
 - [morgana-config.xml](morgana-config.xml) - Morgana configuration file
 - [GRAB-SAXON.xpl](GRAB-SAXON.xpl) - Saxon download and installation pipeline (XProc 3.0)
 - [GRAB-SCHXSLT.xpl](GRAB-SCHXSLT.xpl) - SchXSLT download pipeline (XProc 3.0)
+- [GRAB-XSPEC.xpl](GRAB-XSPECT.xpl) - XSpec download pipeline (current XSpec)
 
 ## Restore
 
 Refresh by deleting everything but the files just named.
 
-Run [setup](../setup.sh) again (or [follow the setup notes](../setup-notes.md)) and the two `GRAB*` pipelines in the folder, to acquire Saxon and SchXSLT for XSLT and Schematron support.
+Run [setup](../setup.sh) again (or [follow the setup notes](../setup-notes.md)) and the three `GRAB*` pipelines in the folder, to acquire libraries for XSLT, Schematron and XSpec support.
 
 Test by running the [smoke tests](../smoketest/).
 
+## Reduce
+
+If you know you don't need a capability (such as XSpec) you don't need to install the library.
+
+If you already have XSpec on your system, you don't need a second copy here.
+
+Accommodate the local pipelines by editing the XSpec pipeline [../xspec/xspec-execute.xpl](../xspec/xspec-execute.xpl). At line 28 where it has
+
+```xml
+<p:variable name="xspec-home"     select="'../lib/xspec-3.0.3/'"/>
+```
+
+Change this to provide an appropriate path on your system, relative to the containing folder.
+
+Also, the sharp-eyed will notice that XSpec also comes with its own copy of SchXSLT.
+
+This suggests you can trim this library further by removing schxslt.
+
+In this case, for Schematron functionality to work in your pipelines, edit the [Morgana configuration file](morgana-config.xml), line 9 (`path_to_SchXSLT_2` element), providing a path to a subdirectory where SchXSLT can be found, inside XProc or elsewhere.
+
+[Smoke tests](../smoketest) can be used to verify functionality after reconfiguration.
 
 ---
 

--- a/setup-notes.md
+++ b/setup-notes.md
@@ -31,6 +31,12 @@ Use [lib/GRAB-SCHXSLT.xpl](lib/GRAB-SCHXSLT.xpl) to pull down SchXSLT.
 
 Or, by hand - find [David Maus's SchXSLT](https://github.com/schxslt/schxslt) on Github. The [distribution you want](https://github.com/schxslt/schxslt/releases/download/v1.9.5/schxslt-1.9.5-xproc.zip) provides XProc support.
 
+## Acquire XSpec for XSpec support
+
+Use [lib/GRAB-XSPEC.xpl](lib/GRAB-XSPEC.xpl) to pull down SchXSLT.
+
+Developers who already have these libraries also have options for using available copies rather than downloading them - see the [lib/readme.md][lib/readme.md].
+
 ### Note on Saxon versions
 
 We have successfully run with Saxon-HE 12.3 and the runtime flag ` -xslt-connector=saxon12-3` when invoking Morgana.

--- a/setup-notes.md
+++ b/setup-notes.md
@@ -25,6 +25,12 @@ Or, by hand - download Saxon-HE 12.3 at https://www.saxonica.com/download/SaxonH
   - Take care no other versions of Saxon are present (which might conflict)
   - Discard the rest if unwanted - keeping the zip file intact for the license information etc.
 
+### Note on Saxon versions
+
+We have successfully run with Saxon-HE 12.3 and the runtime flag ` -xslt-connector=saxon12-3` when invoking Morgana.
+
+Developers who have success with later versions and reasons to need a Saxon upgrade should [please make an Issue](https://github.com/usnistgov/oscal-xproc3/issues) or (better) [a PR](https://github.com/usnistgov/oscal-xproc3/pulls).
+
 ## Acquire SchXSLT for Schematron support
 
 Use [lib/GRAB-SCHXSLT.xpl](lib/GRAB-SCHXSLT.xpl) to pull down SchXSLT.
@@ -33,15 +39,17 @@ Or, by hand - find [David Maus's SchXSLT](https://github.com/schxslt/schxslt) on
 
 ## Acquire XSpec for XSpec support
 
-Use [lib/GRAB-XSPEC.xpl](lib/GRAB-XSPEC.xpl) to pull down SchXSLT.
+Use [lib/GRAB-XSPEC.xpl](lib/GRAB-XSPEC.xpl) to pull down XSpec.
 
-Developers who already have these libraries also have options for using available copies rather than downloading them - see the [lib/readme.md][lib/readme.md].
+## Skip these downloads
 
-### Note on Saxon versions
+Alternatively, developers who already have these libraries can configure to use available copies rather than downloading them - see the [lib/readme.md](lib/readme.md).
 
-We have successfully run with Saxon-HE 12.3 and the runtime flag ` -xslt-connector=saxon12-3` when invoking Morgana.
+- For Saxon, provide the Saxon `jar` to the Morgana runtime (the pipeline does this by copying it into Morgana's `lib` directory; classpath incantations also work).
 
-Developers who have success with later versions and reasons to need a Saxon upgrade should [please make an Issue](https://github.com/usnistgov/oscal-xproc3/issues) or (better) [a PR](https://github.com/usnistgov/oscal-xproc3/pulls).
+- For SchXSLT, edit the [Morgana configuration](lib/morgana-config.xml) or use a different configuration when invoking Morgana.
+
+- for XSpec, edit the top-level [XSpec execution pipeline](xspec/xspec-execute.xpl) or any pipeline that calls into XSpec directly.
 
 ## Check your paths
 
@@ -57,15 +65,17 @@ Likewise, tests are provided that can show that XSLT and Schematron capabilities
 
 - [smoketest/SMOKETEST-XSLT.xpl](smoketest/SMOKETEST-XSLT.xpl)
 - [smoketest/SMOKETEST-SCHEMATRON.xpl](smoketest/SMOKETEST-SCHEMATRON.xpl)
+- [smoketest/SMOKETEST-SCHEMATRON.xpl](smoketest/SMOKETEST-XSPEC.xpl)
 
+Note that since Schematron and XSpec depend on XSLT and hence invoke Saxon, the Saxon-only smoketest can often be skipped.
 
 ### Smoke tests are working but a pipeline doesn't
 
 If the smoke tests work, but a pipeline does not function correctly, any problem is most likely not with installation or configuration, but with the pipeline itself, or in a resource that it reads or requires.
 
-Morgana returns information about errors and warnings in XML format. While this compromises their legibility on the screen, generally speaking the messages embedded are fairly helpful. And this XML is very useful for other purposes, as it can be trapped.
+Morgana returns information about errors and warnings in XML format. While this compromises their legibility on the screen, generally speaking the messages embedded are fairly helpful. And this XML is very useful for other purposes, as it can be trapped and processed further.
 
-Any problems with any pipelines on this site (or any pipelines not otherwise called out in documentation or comments) should be [reported](https://github.com/usnistgov/oscal-xproc3/issues), as it is not our aim to distribute broken software. Of course, if your aim is to learn XProc and XSLT, it is to be hoped you are looking at useful error messages very soon.
+Any problems with any pipelines on this site (or any pipelines not otherwise called out in documentation or comments) should be [reported](https://github.com/usnistgov/oscal-xproc3/issues), as it is not our aim to distribute broken software. Of course, if your aim is to learn XProc and XSLT, we also hope you are looking at useful error messages very soon - signposts on your journey.
 
 ---
 

--- a/smoketest/SMOKETEST-SCHEMATRON.xpl
+++ b/smoketest/SMOKETEST-SCHEMATRON.xpl
@@ -8,11 +8,11 @@
    <!-- assert-valid='false' returns the input document with SVRL on another port
    see https://spec.xproc.org/master/head/validation/#c.validate-with-schematron
    -->
-   <p:validate-with-schematron assert-valid="false">
+   <p:validate-with-schematron assert-valid="true">
       <p:with-input port="schema" href="doing-well.sch"/>
       <p:with-input port="source">
          <p:inline>
-            <CONGRATULATIONS>Congratulations on running an XProc 3 pipeline.</CONGRATULATIONS>
+            <CONGRATULATIONS>Schematron runs under XProc 3.0.</CONGRATULATIONS>
          </p:inline>
       </p:with-input>
    </p:validate-with-schematron>

--- a/smoketest/SMOKETEST-XSPEC.xpl
+++ b/smoketest/SMOKETEST-XSPEC.xpl
@@ -14,5 +14,5 @@
    <ox:xspec-execute name="execute-xspec"/>
    
    <p:identity message="[SMOKETEST-XSPEC] All done, successful run"/>
-   
+
 </p:declare-step>

--- a/smoketest/SMOKETEST-XSPEC.xpl
+++ b/smoketest/SMOKETEST-XSPEC.xpl
@@ -1,0 +1,16 @@
+<p:declare-step xmlns:p="http://www.w3.org/ns/xproc" version="3.0"
+   xmlns:ox="http://csrc.nist.gov/ns/oscal-xproc3"
+   type="ox:SMOKETEST-XSPEC"
+   name="SMOKETEST-XSPEC">
+
+   <p:import href="../xspec/xspec-execute.xpl"/>
+   
+   <p:input port="source">
+     <p:document content-type="application/xml" href="congratulations-xslt.xspec"/>
+   </p:input>
+   
+   <p:identity message="[SMOKETEST-XSPEC] Testing XSpec by running ./congratulations-xslt.xspec"/>
+   
+   <ox:xspec-execute name="execute-xspec"/>
+   
+</p:declare-step>

--- a/smoketest/SMOKETEST-XSPEC.xpl
+++ b/smoketest/SMOKETEST-XSPEC.xpl
@@ -13,4 +13,6 @@
    
    <ox:xspec-execute name="execute-xspec"/>
    
+   <p:identity message="[SMOKETEST-XSPEC] All done, successful run"/>
+   
 </p:declare-step>

--- a/smoketest/doing-well.sch
+++ b/smoketest/doing-well.sch
@@ -13,7 +13,7 @@
    <sch:pattern>
       <sch:rule context="/*">
          <sch:report test="false()">CONGRATULATIONS - you have performed Schematron validation on a <sch:name/> document.</sch:report>
-         <sch:assert test="false()">An assertion should fail when it is false.</sch:assert>
+         <sch:assert test="true()">An assertion should fail when it is false.</sch:assert>
       </sch:rule>
    </sch:pattern>
    

--- a/testing/.gitignore
+++ b/testing/.gitignore
@@ -1,2 +1,2 @@
 # Results of batch XSpec go here
-xspec-reports
+xspec-reports/*

--- a/testing/.gitignore
+++ b/testing/.gitignore
@@ -1,0 +1,2 @@
+# Results of batch XSpec go here
+xspec-reports

--- a/testing/BATCH-XSPEC-JUNIT.xpl
+++ b/testing/BATCH-XSPEC-JUNIT.xpl
@@ -13,22 +13,18 @@
    
    <p:variable name="repo-root" select="resolve-uri('.. ',static-base-uri())  => replace('^file:///','file:/')"/>
    
-   <p:variable name="schematron-path" select="'xproc3-house-rules.sch'"/>
-   <p:variable name="outdir"          select="'xspec-reports' => resolve-uri(static-base-uri())"/>
+   <p:variable name="outdir" select="'xspec-reports' => resolve-uri(static-base-uri())"/>
    
    <ox:TEST-XSPEC-SET name="test-set"/>
    
    <p:for-each>
       <p:with-input pipe="xspec-files@test-set"/>
       <!-- Remember that each input node is a root for its own tree - hence XPath context -->
-      <p:variable name="base" select="base-uri(/*)"/>
-      <p:variable name="repo-path" select="substring-after($base,$repo-root)"/>
-      <p:variable name="html-report-path"  select="replace($repo-path,'\.xspec$','') || '_report.html' "/>
-      <p:variable name="junit-report-path" select="replace($repo-path,'\.xspec$','') || '_junit.xml' "/>
-      <!--<p:identity message="[BATCH-XSPEC] $base: { $base }"/>
-      <p:identity message="[BATCH-XSPEC] $repo-path: { $repo-path }"/>
-      <p:identity message="[BATCH-XSPEC] $repo-root: { $repo-root }"/>-->
-
+      <p:variable name="xspec-filename" select="base-uri(/*)"/>
+      <p:variable name="relative-path" select="substring-after($xspec-filename,$repo-root)"/>
+      <p:variable name="html-report-path"  select="replace($relative-path,'\.xspec$','') || '_report.html' "/>
+      <p:variable name="junit-report-path" select="replace($relative-path,'\.xspec$','') || '_junit.xml' "/>
+      
       <ox:xspec-execute name="execute-xspec"/>
       
       <!--<p:store message="[BATCH-XSPEC-JUNIT] storing HTML report in {$outdir}/{$html-report-path}"   href="{$outdir}/{$html-report-path}">

--- a/testing/BATCH-XSPEC-JUNIT.xpl
+++ b/testing/BATCH-XSPEC-JUNIT.xpl
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<p:declare-step xmlns:p="http://www.w3.org/ns/xproc"
+   xmlns:c="http://www.w3.org/ns/xproc-step" version="3.0"
+   xmlns:ox="http://csrc.nist.gov/ns/oscal-xproc3"
+   type="ox:BATCH-XSPEC"
+   name="BATCH-XSPEC-JUNIT">
+
+   <!-- Executes available XSpecs writing only JUnit results -->
+   
+   <p:import href="TEST-XSPEC-SET.xpl"/>
+   
+   <p:import href="../xspec/xspec-execute.xpl"/>
+   
+   <p:variable name="repo-root" select="resolve-uri('.. ',static-base-uri())  => replace('^file:///','file:/')"/>
+   
+   <p:variable name="schematron-path" select="'xproc3-house-rules.sch'"/>
+   <p:variable name="outdir"          select="'xspec-reports'"/>
+   
+   <ox:TEST-XSPEC-SET name="test-set"/>
+   
+   <p:for-each>
+      <p:with-input pipe="xspec-files@test-set"/>
+      <!-- Remember that each input node is a root for its own tree - hence XPath context -->
+      <p:variable name="base" select="base-uri(/*)"/>
+      <p:variable name="repo-path" select="substring-after($base,$repo-root)"/>
+      <p:variable name="html-report-path"  select="replace($repo-path,'\.xspec$','') || '_report.html' "/>
+      <p:variable name="junit-report-path" select="replace($repo-path,'\.xspec$','') || '_junit.xml' "/>
+      <!--<p:identity message="[BATCH-XSPEC] $base: { $base }"/>
+      <p:identity message="[BATCH-XSPEC] $repo-path: { $repo-path }"/>
+      <p:identity message="[BATCH-XSPEC] $repo-root: { $repo-root }"/>-->
+
+      <ox:xspec-execute name="execute-xspec"/>
+      
+      <!--<p:store message="[BATCH-XSPEC-JUNIT] storing HTML report in {$outdir}/{$html-report-path}"   href="{$outdir}/{$html-report-path}">
+         <p:with-input port="source" pipe="xspec-html-report@execute-xspec"/>
+      </p:store>-->
+      <p:store message="[BATCH-XSPEC-JUNIT] storing JUnit report in {$outdir}/{$junit-report-path}" href="{$outdir}/{$junit-report-path}">
+         <p:with-input port="source" pipe="xspec-junit-report@execute-xspec"/>
+      </p:store>
+      <p:sink/>
+   </p:for-each>
+      
+</p:declare-step>
+

--- a/testing/BATCH-XSPEC-JUNIT.xpl
+++ b/testing/BATCH-XSPEC-JUNIT.xpl
@@ -14,7 +14,7 @@
    <p:variable name="repo-root" select="resolve-uri('.. ',static-base-uri())  => replace('^file:///','file:/')"/>
    
    <p:variable name="schematron-path" select="'xproc3-house-rules.sch'"/>
-   <p:variable name="outdir"          select="'xspec-reports'"/>
+   <p:variable name="outdir"          select="'xspec-reports' => resolve-uri(static-base-uri())"/>
    
    <ox:TEST-XSPEC-SET name="test-set"/>
    

--- a/testing/BATCH-XSPEC.xpl
+++ b/testing/BATCH-XSPEC.xpl
@@ -15,7 +15,7 @@
    <p:variable name="repo-root" select="resolve-uri('.. ',static-base-uri())  => replace('^file:///','file:/')"/>
    
    <p:variable name="schematron-path" select="'xproc3-house-rules.sch'"/>
-   <p:variable name="outdir"          select="'xspec-reports'"/>
+   <p:variable name="outdir"          select="'xspec-reports' => resolve-uri(static-base-uri())"/>
    
    <ox:TEST-XSPEC-SET name="test-set"/>
    

--- a/testing/BATCH-XSPEC.xpl
+++ b/testing/BATCH-XSPEC.xpl
@@ -24,8 +24,8 @@
       <!-- Remember that each input node is a root for its own tree - hence XPath context -->
       <p:variable name="base" select="base-uri(/*)"/>
       <p:variable name="repo-path" select="substring-after($base,$repo-root)"/>
-      <p:variable name="html-report-path"  select="replace($repo-path,'\.xspec$','') || '-report.html' "/>
-      <p:variable name="junit-report-path" select="replace($repo-path,'\.xspec$','') || '-junit.xml' "/>
+      <p:variable name="html-report-path"  select="replace($repo-path,'\.xspec$','') || '_report.html' "/>
+      <p:variable name="junit-report-path" select="replace($repo-path,'\.xspec$','') || '_junit.xml' "/>
       <!--<p:identity message="[BATCH-XSPEC] $base: { $base }"/>
       <p:identity message="[BATCH-XSPEC] $repo-path: { $repo-path }"/>
       <p:identity message="[BATCH-XSPEC] $repo-root: { $repo-root }"/>-->

--- a/testing/BATCH-XSPEC.xpl
+++ b/testing/BATCH-XSPEC.xpl
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<p:declare-step xmlns:p="http://www.w3.org/ns/xproc"
+   xmlns:c="http://www.w3.org/ns/xproc-step" version="3.0"
+   xmlns:ox="http://csrc.nist.gov/ns/oscal-xproc3"
+   type="ox:BATCH-XSPEC"
+   name="BATCH-XSPEC"
+   >
+
+   <!-- Executes available XSpecs -->
+   
+   <p:import href="TEST-XSPEC-SET.xpl"/>
+   
+   <p:import href="../xspec/xspec-execute.xpl"/>
+   
+   <!--<p:output port="result" serialization="map{'indent' : true()}"/>-->
+   
+   <p:variable name="schematron-path" select="'xproc3-house-rules.sch'"/>
+   
+   <ox:TEST-XSPEC-SET name="test-set"/>
+   
+   <p:variable name="repo-root" select="resolve-uri('.. ',static-base-uri())  => replace('^file:///','file:/')"/>
+   <p:for-each>
+      <p:with-input pipe="xspec-files@test-set"/>
+      <!-- Remember that each input node is a root for its own tree - hence XPath context -->
+      <p:variable name="base" select="base-uri(/*)"/>
+      <p:variable name="repo-path" select="substring-after($base,$repo-root)"/>
+      <p:variable name="html-report-path" select="'test_output/' || replace($repo-path,'\.xspec$','') || '-report.html' "/>
+      <p:variable name="junit-report-path" select="'test_output/' || replace($repo-path,'\.xspec$','') || '-junit.xml' "/>
+      <!--<p:identity message="[BATCH-XSPEC] $base: { $base }"/>
+      <p:identity message="[BATCH-XSPEC] $repo-path: { $repo-path }"/>
+      <p:identity message="[BATCH-XSPEC] $repo-root: { $repo-root }"/>-->
+
+      <ox:xspec-execute name="execute-xspec"/>
+      
+      <p:store message="[BATCH-XSPEC] storing HTML report in { $html-report-path }" href="reports/{$html-report-path}">
+         <p:with-input port="source" pipe="xspec-html-report@execute-xspec"/>
+      </p:store>
+      <p:store message="[BATCH-XSPEC] storing JUnit report in { $junit-report-path }" href="reports/{$junit-report-path}">
+         <p:with-input port="source" pipe="xspec-junit-report@execute-xspec"/>
+      </p:store>
+      <p:sink/>
+   </p:for-each>
+      
+</p:declare-step>
+

--- a/testing/BATCH-XSPEC.xpl
+++ b/testing/BATCH-XSPEC.xpl
@@ -12,30 +12,30 @@
    
    <p:import href="../xspec/xspec-execute.xpl"/>
    
-   <!--<p:output port="result" serialization="map{'indent' : true()}"/>-->
+   <p:variable name="repo-root" select="resolve-uri('.. ',static-base-uri())  => replace('^file:///','file:/')"/>
    
    <p:variable name="schematron-path" select="'xproc3-house-rules.sch'"/>
+   <p:variable name="outdir"          select="'xspec-reports'"/>
    
    <ox:TEST-XSPEC-SET name="test-set"/>
    
-   <p:variable name="repo-root" select="resolve-uri('.. ',static-base-uri())  => replace('^file:///','file:/')"/>
    <p:for-each>
       <p:with-input pipe="xspec-files@test-set"/>
       <!-- Remember that each input node is a root for its own tree - hence XPath context -->
       <p:variable name="base" select="base-uri(/*)"/>
       <p:variable name="repo-path" select="substring-after($base,$repo-root)"/>
-      <p:variable name="html-report-path" select="'test_output/' || replace($repo-path,'\.xspec$','') || '-report.html' "/>
-      <p:variable name="junit-report-path" select="'test_output/' || replace($repo-path,'\.xspec$','') || '-junit.xml' "/>
+      <p:variable name="html-report-path"  select="replace($repo-path,'\.xspec$','') || '-report.html' "/>
+      <p:variable name="junit-report-path" select="replace($repo-path,'\.xspec$','') || '-junit.xml' "/>
       <!--<p:identity message="[BATCH-XSPEC] $base: { $base }"/>
       <p:identity message="[BATCH-XSPEC] $repo-path: { $repo-path }"/>
       <p:identity message="[BATCH-XSPEC] $repo-root: { $repo-root }"/>-->
 
       <ox:xspec-execute name="execute-xspec"/>
       
-      <p:store message="[BATCH-XSPEC] storing HTML report in { $html-report-path }" href="reports/{$html-report-path}">
+      <p:store message="[BATCH-XSPEC] storing HTML report in {$outdir}/{$html-report-path}"   href="{$outdir}/{$html-report-path}">
          <p:with-input port="source" pipe="xspec-html-report@execute-xspec"/>
       </p:store>
-      <p:store message="[BATCH-XSPEC] storing JUnit report in { $junit-report-path }" href="reports/{$junit-report-path}">
+      <p:store message="[BATCH-XSPEC] storing JUnit report in {$outdir}/{$junit-report-path}" href="{$outdir}/{$junit-report-path}">
          <p:with-input port="source" pipe="xspec-junit-report@execute-xspec"/>
       </p:store>
       <p:sink/>

--- a/testing/BATCH-XSPEC.xpl
+++ b/testing/BATCH-XSPEC.xpl
@@ -14,22 +14,18 @@
    
    <p:variable name="repo-root" select="resolve-uri('.. ',static-base-uri())  => replace('^file:///','file:/')"/>
    
-   <p:variable name="schematron-path" select="'xproc3-house-rules.sch'"/>
-   <p:variable name="outdir"          select="'xspec-reports' => resolve-uri(static-base-uri())"/>
+   <p:variable name="outdir" select="'xspec-reports' => resolve-uri(static-base-uri())"/>
    
    <ox:TEST-XSPEC-SET name="test-set"/>
    
    <p:for-each>
       <p:with-input pipe="xspec-files@test-set"/>
       <!-- Remember that each input node is a root for its own tree - hence XPath context -->
-      <p:variable name="base" select="base-uri(/*)"/>
-      <p:variable name="repo-path" select="substring-after($base,$repo-root)"/>
-      <p:variable name="html-report-path"  select="replace($repo-path,'\.xspec$','') || '_report.html' "/>
-      <p:variable name="junit-report-path" select="replace($repo-path,'\.xspec$','') || '_junit.xml' "/>
-      <!--<p:identity message="[BATCH-XSPEC] $base: { $base }"/>
-      <p:identity message="[BATCH-XSPEC] $repo-path: { $repo-path }"/>
-      <p:identity message="[BATCH-XSPEC] $repo-root: { $repo-root }"/>-->
-
+      <p:variable name="xspec-filename" select="base-uri(/*)"/>
+      <p:variable name="relative-path" select="substring-after($xspec-filename,$repo-root)"/>
+      <p:variable name="html-report-path"  select="replace($relative-path,'\.xspec$','') || '_report.html' "/>
+      <p:variable name="junit-report-path" select="replace($relative-path,'\.xspec$','') || '_junit.xml' "/>
+      
       <ox:xspec-execute name="execute-xspec"/>
       
       <p:store message="[BATCH-XSPEC] storing HTML report in {$outdir}/{$html-report-path}"   href="{$outdir}/{$html-report-path}">

--- a/testing/TEST-XPROC-SET.xpl
+++ b/testing/TEST-XPROC-SET.xpl
@@ -16,6 +16,7 @@
       <p:document href="TEST-XPROC-SET.xpl"/>
       <p:document href="TEST-XSPEC-SET.xpl"/>
       <p:document href="BATCH-XSPEC.xpl"/>
+      <p:document href="BATCH-XSPEC-JUNIT.xpl"/>
       <p:document href="BATCH-XPROC3-HOUSE-RULES.xpl"/>
       <p:document href="HARDFAIL-XPROC3-HOUSE-RULES.xpl"/>
       <p:document href="REPO-XPROC3-HOUSE-RULES.xpl"/>

--- a/testing/TEST-XPROC-SET.xpl
+++ b/testing/TEST-XPROC-SET.xpl
@@ -11,7 +11,11 @@
    <p:input port="source" sequence="true">
       <p:document href="../lib/GRAB-SAXON.xpl"/>
       <p:document href="../lib/GRAB-SCHXSLT.xpl"/>
-
+      <p:document href="../lib/GRAB-XSPEC.xpl"/>
+      
+      <p:document href="TEST-XPROC-SET.xpl"/>
+      <p:document href="TEST-XSPEC-SET.xpl"/>
+      <p:document href="BATCH-XSPEC.xpl"/>
       <p:document href="BATCH-XPROC3-HOUSE-RULES.xpl"/>
       <p:document href="HARDFAIL-XPROC3-HOUSE-RULES.xpl"/>
       <p:document href="REPO-XPROC3-HOUSE-RULES.xpl"/>
@@ -27,8 +31,10 @@
       <p:document href="../smoketest/POWER-UP.xpl"/>
       <p:document href="../smoketest/SMOKETEST-SCHEMATRON.xpl"/>
       <p:document href="../smoketest/SMOKETEST-XSLT.xpl"/>
-      <p:document href="../smoketest/SMOKETEST-XSLT.xpl"/>
+      <p:document href="../smoketest/SMOKETEST-XSPEC.xpl"/>
 
+      <p:document href="../xspec/xspec-execute.xpl"/>
+      
       <p:document href="../profile-resolution/setup/ACQUIRE-OSCAL-DATA.xpl"/>
       <p:document href="../profile-resolution/setup/GRAB-PROFILE-RESOLVER-XSLT.xpl"/>
       <p:document href="../profile-resolution/src/apply-profile-resolver.xpl"/>

--- a/testing/TEST-XSPEC-SET.xpl
+++ b/testing/TEST-XSPEC-SET.xpl
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<p:declare-step xmlns:p="http://www.w3.org/ns/xproc"
+   xmlns:c="http://www.w3.org/ns/xproc-step" version="3.0"
+   xmlns:ox="http://csrc.nist.gov/ns/oscal-xproc3"
+   type="ox:TEST-XSPEC-SET"
+   name="TEST-XSPEC-SET"
+   >
+
+   <!-- Pipeline to be called as subpipeline, delivering a list of XProcs -->
+   
+   <p:input port="source" sequence="true">
+      <!-- We need content type because xspec suffix throws off the parser -->
+      <p:document href="../smoketest/congratulations-xslt.xspec" content-type="application/xml"/>
+      
+   </p:input>
+ 
+   <p:output port="xspec-files" sequence="true"/>
+   
+   <p:identity/>
+   
+</p:declare-step>

--- a/xp3.sh
+++ b/xp3.sh
@@ -27,6 +27,6 @@ elif [ "${1:-}" = '-h' ] || [ "${1:-}" = '--help' ]; then usage
 
 else
 
-  ${MORGANA} -config=lib/morgana-config.xml $@ -indent-errors
+  ${MORGANA} -config="${SCRIPT_DIR}/lib/morgana-config.xml" $@ -indent-errors
 
 fi

--- a/xspec/readme.md
+++ b/xspec/readme.md
@@ -1,0 +1,51 @@
+# XSpec project
+
+*Important* - this project
+
+- Depends on successful installation of XSpec using the pipeline [../lib/GRAB-XSPEC.xpl](../lib/GRAB-XSPEC.xpl)
+- Provides XSpec support under XProc 3.0
+  - As demonstrated by test files here
+  - But also usable throughout the repository
+  
+When working with this project take care, as pipelines defined here may be used across the repository.
+
+## Approach
+
+- Minimal modifications of XSpec to apply it in this runtime 
+- Reuse as much as possible
+- Don't worry about advanced capabilities, basics are okay for now
+- Ideally, test and demo each of
+  - XSpec for XSLT
+  - XSpec for Schematron
+  - XSpec for XQuery
+
+## Contents
+
+- XProc 3.0 in the file system here mirrors XProc giving with XSpec
+
+## Punchlist
+
+- Analyze, trace and rebuild  XProc runtime for XSpec
+  - The directory [xspec-dev](xspec-dev) in this project folder is at the same level as the local copy of the XSpec distribution saved out by [../lib/GRAB-XSPEC.xpl](../lib/GRAB-XSPEC.xpl)
+  - Accordingly, its XProc 1.0 can simply be mirrored and updated (Famous Last Words)
+
+- Illustrate with some XSpecs in action
+  - runtime messages
+  - HTML report
+  - JUnit report
+  - In batches
+
+- Cover XSLT, Schematron, XQuery
+
+## For later
+
+- XSpec comes with SchXSLT - should we consolidate?
+  - At least note as a possible optimization
+
+      
+## Acknowledgements
+
+Florent Georges is the author of the XProc 1.0 pipelines we seek to re-engineer in this project.
+
+Other XSpec contributors have played roles as well in bringing us this far.
+---

--- a/xspec/readme.md
+++ b/xspec/readme.md
@@ -7,7 +7,7 @@
   - As demonstrated by test files here
   - But also usable throughout the repository
   
-When working with this project take care, as pipelines defined here may be used across the repository.
+When working with this project take care, as pipelines defined here may be used to run XSpec in other project folders. Running `make test` from the top helps ensure nothing is broken by accident.
 
 ## Approach
 
@@ -21,31 +21,40 @@ When working with this project take care, as pipelines defined here may be used 
 
 ## Contents
 
-- XProc 3.0 in the file system here mirrors XProc giving with XSpec
+- XProc 3.0 in the file system here provides XSpec evaluation in pipelines.
+
+## Notes of interest
+
+### Patching the compiler XSLT
+
+XSpec works by transpiling an XSpec into an XSLT and then executing it. These XSLTs all work fine in their current form, apart from a small problem resulting from a bug (or lapse in specification) in Morgana, which drops results from `xsl:result-document` when no `@href` is given.
+
+Accordingly, we provide a slight amendment to the XSLT produced by the compiler, before executing it.
+
+See [xspec-execute.xpl](xspec-execute.xpl) for this code. The change is made dynamically in the pipeline, and produces the results needed.
+
+### Seeing XSpec as XSpec
+
+Because xspec files are typically not named `*.xml` they may not be recognized as XML by an XProc engine, for parsing. You will get an error for not knowing what to do with an octet stream.
+
+To mitigate this, call the document in (`p:document` or `p:load`) with `content-type="application/xml"`.
+
+(Passing the name on the command line is still a problem.)
 
 ## Punchlist
 
-- Analyze, trace and rebuild  XProc runtime for XSpec
-  - The directory [xspec-dev](xspec-dev) in this project folder is at the same level as the local copy of the XSpec distribution saved out by [../lib/GRAB-XSPEC.xpl](../lib/GRAB-XSPEC.xpl)
-  - Accordingly, its XProc 1.0 can simply be mirrored and updated (Famous Last Words)
-
-- Illustrate with some XSpecs in action
-  - runtime messages
-  - HTML report
-  - JUnit report
-  - In batches
-
-- Cover XSLT, Schematron, XQuery
+- Schematron
+- XQuery
 
 ## For later
 
 - XSpec comes with SchXSLT - should we consolidate?
   - At least note as a possible optimization
-
       
 ## Acknowledgements
 
-Florent Georges is the author of the XProc 1.0 pipelines we seek to re-engineer in this project.
+Florent Georges is the author of the XProc 1.0 pipelines we are emulating in this project.
 
-Other XSpec contributors have played roles as well in bringing us this far.
+Other XSpec contributors have played important roles as well in bringing us this far.
+
 ---

--- a/xspec/xspec-execute.xpl
+++ b/xspec/xspec-execute.xpl
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<p:declare-step xmlns:p="http://www.w3.org/ns/xproc"
+   xmlns:c="http://www.w3.org/ns/xproc-step" version="3.0"
+   xmlns:x="http://www.jenitennison.com/xslt/xspec"
+   name="xspec-execute"
+   type="ox:xspec-execute" xmlns:ox="http://csrc.nist.gov/ns/oscal-xproc3">
+
+<!-- XProc 3.0 rendition of saxon-xslt-harness
+     -->
+<!-- Credit: Florent Georges is the author of the original XProc 1.0 XSpec testing harnesses, which this code (in its first iteration) sets out to emulate -->
+
+   <p:input port="xspec-source" primary="true" content-types="application/xml">
+      <p:document href="../smoketest/congratulations-xslt.xspec" content-type="application/xml"/>
+   </p:input>
+   
+   <p:output port="xspec-html-report" primary="true" pipe="result@html-report"/>
+   
+   <p:output port="xspec-junit-report" primary="false" pipe="result@junit-report"/>
+  
+   <!--<p:output port="compiled-xspec" pipe="result@compile-xspec"/>-->
+   
+    <!--<p:output port="xspec-report" primary="true" sequence="true" pipe="secondary@execute-xspec"/>-->
+   
+   <!--<p:output port="result" pipe="result@end"/>-->
+   
+<!-- compile the XSpec -->
+
+   <p:variable name="xspec-home"     select="'../lib/xspec-3.0.3/'"/>
+   <p:variable name="compiler-xslt"  select="$xspec-home || 'src/compiler/compile-xslt-tests.xsl'"/>
+   <p:variable name="formatter-xslt" select="$xspec-home || 'src/reporter/format-xspec-report.xsl'"/>
+   <p:variable name="junit-xslt"     select="$xspec-home || 'src/reporter/junit-report.xsl'"/>
+   
+   <p:xslt name="compile-xspec">
+      <!--<p:with-input port="source" pipe="xspec-source@xspec-execute"/>-->
+   <!--   <p:with-input port="source">
+         <p:document href="../smoketest/congratulations-xslt.xspec" content-types="text/xml"/>
+      </p:with-input>
+-->      <p:with-input port="stylesheet" href="{ $compiler-xslt }"/>
+   </p:xslt>
+   
+<!-- Some surgery must be performed on the compiled XSLT ...  -->
+   <p:add-attribute name="adjusted-runtime"
+      match="/*/xsl:template[@name='Q{{http://www.jenitennison.com/xslt/xspec}}main']/xsl:result-document"
+      attribute-name="href" attribute-value="report"
+      xmlns:xsl="http://www.w3.org/1999/XSL/Transform" />
+   
+   <!-- run the XSLT -->
+
+   <p:xslt name="execute-xspec">
+      <p:with-input port="source"><p:empty/></p:with-input>
+      <p:with-input port="stylesheet" pipe="result@adjusted-runtime"/>
+      <p:with-option name="template-name" select="'Q{http://www.jenitennison.com/xslt/xspec}main'"/>
+   </p:xslt>
+   
+   <p:identity name="xspec-report">
+      <p:with-input port="source" pipe="secondary@execute-xspec"/>
+   </p:identity>
+   
+   <!-- format the report -->
+
+   
+   <!--<x:report stylesheet="bogus.xsl" xspec="dummy.xspec" date="2024-04-01T16:26:29.142753100-04:00"/>-->
+   
+   <p:xslt name="html-report">
+      <p:with-input port="stylesheet" href="{ $formatter-xslt }"/>
+      <p:with-option name="parameters" select="map { 'inline-css': 'true' }"/>
+   </p:xslt>
+   
+   <p:string-replace match="text()" replace="translate(., '', '&lt;&gt;')"/>
+   
+   <p:sink/>
+   
+   <p:xslt name="junit-report">
+      <p:with-input port="source" pipe="result@xspec-report"/>
+      <!--<p:with-input port="source">
+         <x:report stylesheet="bogus.xsl" xspec="dummy.xspec" date="2024-04-01T16:26:29.142753100-04:00"/>
+      </p:with-input>-->
+      <p:with-input port="stylesheet" href="{ $junit-xslt }"/>
+      
+   </p:xslt>
+   <!--
+   
+   <p:identity name="end"/>-->
+   
+</p:declare-step>

--- a/xspec/xspec-execute.xpl
+++ b/xspec/xspec-execute.xpl
@@ -16,36 +16,25 @@
    <p:output port="xspec-html-report" primary="true" pipe="result@html-report"/>
    
    <p:output port="xspec-junit-report" primary="false" pipe="result@junit-report"/>
-  
-   <!--<p:output port="compiled-xspec" pipe="result@compile-xspec"/>-->
-   
-    <!--<p:output port="xspec-report" primary="true" sequence="true" pipe="secondary@execute-xspec"/>-->
-   
-   <!--<p:output port="result" pipe="result@end"/>-->
-   
-<!-- compile the XSpec -->
 
+   <!-- Provide a relative path to XSpec (top-level directory) on this system -->
    <p:variable name="xspec-home"     select="'../lib/xspec-3.0.3/'"/>
+   
    <p:variable name="compiler-xslt"  select="$xspec-home || 'src/compiler/compile-xslt-tests.xsl'"/>
    <p:variable name="formatter-xslt" select="$xspec-home || 'src/reporter/format-xspec-report.xsl'"/>
    <p:variable name="junit-xslt"     select="$xspec-home || 'src/reporter/junit-report.xsl'"/>
    
    <p:xslt name="compile-xspec">
-      <!--<p:with-input port="source" pipe="xspec-source@xspec-execute"/>-->
-   <!--   <p:with-input port="source">
-         <p:document href="../smoketest/congratulations-xslt.xspec" content-types="text/xml"/>
-      </p:with-input>
--->      <p:with-input port="stylesheet" href="{ $compiler-xslt }"/>
+     <p:with-input port="stylesheet" href="{ $compiler-xslt }"/>
    </p:xslt>
    
-<!-- Some surgery must be performed on the compiled XSLT ...  -->
+   <!-- A small adjustment to the compiled XSLT wakes up the 'secondary' port where we can see it ...  -->
    <p:add-attribute name="adjusted-runtime"
       match="/*/xsl:template[@name='Q{{http://www.jenitennison.com/xslt/xspec}}main']/xsl:result-document"
       attribute-name="href" attribute-value="report"
       xmlns:xsl="http://www.w3.org/1999/XSL/Transform" />
    
    <!-- run the XSLT -->
-
    <p:xslt name="execute-xspec">
       <p:with-input port="source"><p:empty/></p:with-input>
       <p:with-input port="stylesheet" pipe="result@adjusted-runtime"/>
@@ -56,10 +45,7 @@
       <p:with-input port="source" pipe="secondary@execute-xspec"/>
    </p:identity>
    
-   <!-- format the report -->
-
-   
-   <!--<x:report stylesheet="bogus.xsl" xspec="dummy.xspec" date="2024-04-01T16:26:29.142753100-04:00"/>-->
+   <!-- A report looks like: <x:report stylesheet="bogus.xsl" xspec="dummy.xspec" date="2024-04-01T16:26:29.142753100-04:00"/> -->
    
    <p:xslt name="html-report">
       <p:with-input port="stylesheet" href="{ $formatter-xslt }"/>
@@ -72,14 +58,7 @@
    
    <p:xslt name="junit-report">
       <p:with-input port="source" pipe="result@xspec-report"/>
-      <!--<p:with-input port="source">
-         <x:report stylesheet="bogus.xsl" xspec="dummy.xspec" date="2024-04-01T16:26:29.142753100-04:00"/>
-      </p:with-input>-->
       <p:with-input port="stylesheet" href="{ $junit-xslt }"/>
-      
    </p:xslt>
-   <!--
-   
-   <p:identity name="end"/>-->
    
 </p:declare-step>


### PR DESCRIPTION
# Committer Notes

Merging XSpec work into main on fork repository in an effort to wake up CI/CD, or at any rate to simplify diagnostics.


### All Submissions:

- [x] Follow [Contributing](https://github.com/usnistgov/oscal-xproc3/blob/main/CONTRIBUTING.md) guidelines
- [x] Make no changes duplicating or conflicting with other open [Pull Requests](https://github.com/usnistgov/oscal-xproc3/pulls)
- [x] Have been squashed to keep only relevant interim commits, if any \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [x] Have been tested manually
- [x] Pass all CI/CD checks

### Changes to Core Features:

- [x] The Issue history, discussions and new documentation provide context for new features -- everything is reasonably self-explanatory
- [x] New tests are included
- [x] New examples are included
- [x] Everything in readme and TESTING documents has been updated
